### PR TITLE
Use Calypso i18n package.

### DIFF
--- a/jp-cloud-strings.pot
+++ b/jp-cloud-strings.pot
@@ -1,0 +1,80 @@
+# THIS IS A GENERATED FILE. DO NOT EDIT DIRECTLY.
+
+msgid ""
+msgstr ""
+"Project-Id-Version: _s \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-10-07T12:15:02.047Z\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"PO-Revision-Date: 2014-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+
+#: src/hello-world/index.js:95
+msgid "API Requests Tests"
+msgstr ""
+
+#: src/hello-world/index.js:98
+msgid "Public API call"
+msgstr ""
+
+#: src/hello-world/index.js:112
+msgid "Backups via authenticated call"
+msgstr ""
+
+#: src/hello-world/index.js:135
+msgid "Load more items"
+msgstr ""
+
+#: extras/date.js:4
+msgctxt "future time"
+msgid "in %s"
+msgstr ""
+
+#: extras/date.js:5
+msgid "a few seconds"
+msgstr ""
+
+#: extras/date.js:6
+msgid "a minute"
+msgstr ""
+
+#: extras/date.js:7
+msgid "%d minutes"
+msgstr ""
+
+#: extras/date.js:8
+msgid "%d hours"
+msgstr ""
+
+#: extras/date.js:9
+msgid "%d days"
+msgstr ""
+
+#: extras/date.js:10
+msgid "a month"
+msgstr ""
+
+#: extras/date.js:11
+msgid "%d months"
+msgstr ""
+
+#: extras/date.js:12
+msgid "a year"
+msgstr ""
+
+#: extras/date.js:13
+msgid "%d years"
+msgstr ""
+
+#: extras/date.js:17
+msgid "number_format_thousands_sep"
+msgstr ""
+
+#: extras/date.js:19
+msgid "number_format_decimal_point"
+msgstr ""
+
+# THIS IS THE END OF THE GENERATED FILE.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
 	"main": "build/index.js",
 	"scripts": {
 		"start": "wp-scripts start",
-		"build": "wp-scripts build"
+		"build": "wp-scripts build",
+		"translate": "i18n-calypso --format pot --output-file ./jp-cloud-strings.pot -k translate,__,_x,_n,_nx -e date '**/*.js' '**/*.jsx' '!build/**' '!public/**' '!node_modules/**' '!**/node_modules/**'"
 	},
 	"keywords": [
 		"jetpack",
@@ -28,8 +29,8 @@
 		"@wordpress/components": "8.3.1",
 		"@wordpress/date": "3.5.0",
 		"@wordpress/element": "^2.8.1",
-		"@wordpress/i18n": "3.6.1",
 		"@wordpress/url": "2.8.0",
+		"i18n-calypso": "3.0.0",
 		"lodash": "^4.17.15",
 		"wpcom": "5.4.2",
 		"wpcom-oauth-cors": "1.0.2-beta"

--- a/src/hello-world/index.js
+++ b/src/hello-world/index.js
@@ -100,7 +100,7 @@ const HelloWorld = () => {
 					<PanelRow>
 						<ul>
 							{ posts.map( ( { id, title } ) => (
-								<li key={ id } dangerouslySetInnerHTML={ { translatehtml: title.rendered } } />
+								<li key={ id } dangerouslySetInnerHTML={ { __html: title.rendered } } />
 							) ) }
 						</ul>
 					</PanelRow>

--- a/src/hello-world/index.js
+++ b/src/hello-world/index.js
@@ -12,7 +12,7 @@ import { getQueryArg } from '@wordpress/url';
  */
 import wpcom from 'wpcom';
 import wpcomOAuth from 'wpcom-oauth-cors';
-import { translate as __ } from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 import { get } from 'lodash';
 
 const CLIENT_ID = '67055';
@@ -90,24 +90,24 @@ const HelloWorld = () => {
 	}, [ api, backupsPage ] );
 
 	return (
-		<Panel header={ __( 'API Requests Tests' ) }>
+		<Panel header={ translate( 'API Requests Tests' ) }>
 			{ posts && (
 				<PanelBody
-					title={ __( 'Public API call' ) }
+					title={ translate( 'Public API call' ) }
 					icon=""
 					initialOpen={ false }
 				>
 					<PanelRow>
 						<ul>
 							{ posts.map( ( { id, title } ) => (
-								<li key={ id } dangerouslySetInnerHTML={ { __html: title.rendered } } />
+								<li key={ id } dangerouslySetInnerHTML={ { translatehtml: title.rendered } } />
 							) ) }
 						</ul>
 					</PanelRow>
 				</PanelBody>
 			) }
 			<PanelBody
-				title={ __( 'Backups via authenticated call' ) }
+				title={ translate( 'Backups via authenticated call' ) }
 				icon=""
 				initialOpen={ true }
 			>
@@ -130,7 +130,7 @@ const HelloWorld = () => {
 						onClick={ loadMoreItems }
 						isPrimary
 						disabled={ ! hasMorePages() || isLoading }>
-						{ __( 'Load more items' ) }
+						{ translate( 'Load more items' ) }
 					</Button>
 				</PanelRow>
 			</PanelBody>

--- a/src/hello-world/index.js
+++ b/src/hello-world/index.js
@@ -4,7 +4,6 @@
 import apiFetch from '@wordpress/api-fetch';
 import { useState, useEffect } from '@wordpress/element';
 import { Button, Panel, PanelBody, PanelRow, Spinner } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
 import { dateI18n } from '@wordpress/date';
 import { getQueryArg } from '@wordpress/url';
 
@@ -13,6 +12,7 @@ import { getQueryArg } from '@wordpress/url';
  */
 import wpcom from 'wpcom';
 import wpcomOAuth from 'wpcom-oauth-cors';
+import { translate as __ } from 'i18n-calypso';
 import { get } from 'lodash';
 
 const CLIENT_ID = '67055';


### PR DESCRIPTION
This PR introduces the following changes:
* Replace `@wordpress/i18n` with Calypso i18n package
* Add translate script
* Generate pot file